### PR TITLE
Push image change events to Discord webhook

### DIFF
--- a/client/web/scripts/index.js
+++ b/client/web/scripts/index.js
@@ -3,7 +3,34 @@ const dato = document.getElementById("dato");
 const imageMagic = createImageMagic({
   target: "#kropp",
   images,
+  onChanged: publishImageInformation,
 });
+
+// If a global `hookUrl` is set and we are online, notify webhook when image changes
+function publishImageInformation(image) {
+  if (hookUrl && kropp.classList.contains("success")) {
+    fetch(hookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        embeds: [
+          {
+            title: image.title,
+            author: { name: image.creator },
+            image: {
+              url: image.url,
+            },
+            footer: {
+              text: `Check out this masterwork of a competition entry, and others like it at ${image.source}`,
+            },
+          },
+        ],
+      }),
+    });
+  }
+}
 
 /**
  * padding number with leading zeroes so it becomes two digits no matter what


### PR DESCRIPTION
This should "just work", as long as we are able to provide the `hookUrl` variable without exposing it to the general public 😄  Should ideally be one url per station, just to reduce chance of getting throttled if all stations are online at the same time.

Having this in place would make sure we don't have any credit issues if details are hard to make out while looking at webcam stream... and hopefully also be a fun little thing for participants to get the proper TG feeling.